### PR TITLE
Ensure upload navigation button re-enables after failed upload

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -135,6 +135,7 @@ async function processFile(file) {
     setUploadFeedback(error.message || 'Upload failed', 'error');
   } finally {
     fileInput.value = '';
+    uploadNextButton.disabled = !state.upload;
   }
 }
 


### PR DESCRIPTION
## Summary
- toggle the upload step navigation button based on whether an upload is stored
- ensure the button becomes interactive again after upload errors while still blocking progress without a saved upload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e210fe9d7c832ea72225efd7d98f16