### PR TITLE
Fix API base detection when serving client separately

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,4 +1,22 @@
-const API_BASE = window.location.origin.replace(/\/$/, '');
+function determineApiBase() {
+  if (window.API_BASE_URL) {
+    return window.API_BASE_URL.replace(/\/$/, '');
+  }
+
+  const meta = document.querySelector('meta[name="api-base"]');
+  if (meta && meta.content) {
+    return meta.content.replace(/\/$/, '');
+  }
+
+  const { protocol, hostname, port } = window.location;
+  if (!port || port === '4000') {
+    return `${protocol}//${hostname}${port ? `:${port}` : ''}`.replace(/\/$/, '');
+  }
+
+  return `${protocol}//${hostname}:4000`;
+}
+
+const API_BASE = determineApiBase();
 
 const state = {
   upload: null,

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,11 @@ EXPO_PUBLIC_API_BASE_URL=http://192.168.1.10:4000 expo start
 | `JWT_SECRET` | Secret used when minting video session tokens         | `development-secret-change-me`   |
 Navigate to [http://localhost:4000](http://localhost:4000) to launch the client.
 
+When serving the static client from a different port (for example via `npx http-server client`), the browser-based experience
+will automatically fall back to `http://<host>:4000` for API calls. To target an alternative origin, set either a global
+`window.API_BASE_URL` variable before `app.js` loads or add `<meta name="api-base" content="https://your-api.example.com" />`
+to `client/index.html`.
+
 ## Environment variables
 
 | Name        | Description                                                   | Default                      |


### PR DESCRIPTION
## Summary
- add dynamic API base detection that falls back to the server port when the static client is hosted elsewhere
- document how to override the API origin when serving the static bundle from a different host

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21320fb58832eb8cfa06219db099b