### PR TITLE
Add Protean OTP verification stub

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -97,6 +97,28 @@ function resetOtpStep() {
   otpCompletionMessage.className = 'feedback';
 }
 
+async function verifyOtpWithProtean(participant, code) {
+  // TODO: Replace this stub with an integration to the Protean verification API.
+  // The actual implementation should call the remote service with the participant's
+  // Aadhaar number and OTP code, and resolve based on the API response.
+  console.info('Invoking Protean OTP verification (placeholder)', {
+    participantId: participant?.id,
+    aadhaar: participant?.aadhaar,
+  });
+
+  // Simulate network latency so the UI reflects an asynchronous call.
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  const success = code === '123456';
+
+  return {
+    success,
+    message: success
+      ? 'Protean verification succeeded (using demo OTP 123456).'
+      : 'Protean verification failed. Use OTP 123456 while testing.',
+  };
+}
+
 function readFileAsBase64(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -344,14 +366,27 @@ async function handleVerifyOtp(participantId, codeInput, statusElement, submitBu
     return;
   }
 
+  const participant = state.session.participants?.find((item) => item.id === participantId);
+  if (!participant) {
+    statusElement.textContent = 'Participant information unavailable.';
+    return;
+  }
+
   submitButton.disabled = true;
   codeInput.disabled = true;
-  statusElement.textContent = 'Verifying…';
+  statusElement.textContent = 'Verifying with Protean…';
 
   let nextSession = null;
   let success = false;
 
   try {
+    const proteanResult = await verifyOtpWithProtean(participant, code);
+    if (!proteanResult.success) {
+      throw new Error(proteanResult.message || 'Protean verification failed');
+    }
+
+    statusElement.textContent = proteanResult.message || 'Protean verification succeeded.';
+
     const response = await fetch(`${API_BASE}/api/sessions/${state.session.id}/otp/${participantId}/verify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/client/app.js
+++ b/client/app.js
@@ -97,6 +97,28 @@ function resetOtpStep() {
   otpCompletionMessage.className = 'feedback';
 }
 
+async function verifyOtpWithProtean(participant, code) {
+  // TODO: Replace this stub with an integration to the Protean verification API.
+  // The actual implementation should call the remote service with the participant's
+  // Aadhaar number and OTP code, and resolve based on the API response.
+  console.info('Invoking Protean OTP verification (placeholder)', {
+    participantId: participant?.id,
+    aadhaar: participant?.aadhaar,
+  });
+
+  // Simulate network latency so the UI reflects an asynchronous call.
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  const success = code === '123456';
+
+  return {
+    success,
+    message: success
+      ? 'Protean verification succeeded (using demo OTP 123456).'
+      : 'Protean verification failed. Use OTP 123456 while testing.',
+  };
+}
+
 function readFileAsBase64(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -344,14 +366,27 @@ async function handleVerifyOtp(participantId, codeInput, statusElement, submitBu
     return;
   }
 
+  const participant = state.session.participants?.find((item) => item.id === participantId);
+  if (!participant) {
+    statusElement.textContent = 'Participant information unavailable.';
+    return;
+  }
+
   submitButton.disabled = true;
   codeInput.disabled = true;
-  statusElement.textContent = 'Verifying…';
+  statusElement.textContent = 'Verifying with Protean…';
 
   let nextSession = null;
   let success = false;
 
   try {
+    const proteanResult = await verifyOtpWithProtean(participant, code);
+    if (!proteanResult.success) {
+      throw new Error(proteanResult.message || 'Protean verification failed');
+    }
+
+    statusElement.textContent = proteanResult.message || 'Protean verification succeeded.';
+
     const response = await fetch(`${API_BASE}/api/sessions/${state.session.id}/otp/${participantId}/verify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- add a placeholder helper that documents where the Protean Aadhaar/OTP API should be invoked
- wire the Protean verification stub into the OTP confirmation flow with demo OTP 123456 messaging
- guard against missing participant data before attempting verification

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e221d90268832eafb6ddd27d9ef72b